### PR TITLE
Fix issue on Android due to measurment.y being null

### DIFF
--- a/src/ElementContainer.js
+++ b/src/ElementContainer.js
@@ -142,7 +142,7 @@ export class ElementContainer extends PureComponent {
 
         gesturePosition.setOffset({
             x: 0,
-            y: selectedMeasurement.y,
+            y: (selectedMeasurement && selectedMeasurement.y) || 0,
         });
 
         Animated.timing(this._opacity, {


### PR DESCRIPTION
Some Android apps are breaking when zooming; this will fix it.